### PR TITLE
Add nytimes/author route

### DIFF
--- a/docs/en/traditional-media.md
+++ b/docs/en/traditional-media.md
@@ -437,6 +437,14 @@ Provides a better reading experience (full text articles) over the official one.
 
 </RouteEn>
 
+### News by author
+
+<RouteEn author="kevinschaul" example="/nytimes/author/farhad-manjoo" path="/nytimes/book/:author" :paramsDesc="['Author’s name in New York Times’ URL format']">
+
+Provides all of the articles by the specified New York Times author.
+
+</RouteEn>
+
 ### Best Seller Books
 
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -237,6 +237,7 @@ router.get('/yande.re/post/popular_recent/:period', lazyloadRouteHandler('./rout
 // 纽约时报
 router.get('/nytimes/daily_briefing_chinese', lazyloadRouteHandler('./routes/nytimes/daily_briefing_chinese'));
 router.get('/nytimes/book/:category?', lazyloadRouteHandler('./routes/nytimes/book.js'));
+router.get('/nytimes/author/:byline?', lazyloadRouteHandler('./routes/nytimes/author.js'));
 router.get('/nytimes/:lang?', lazyloadRouteHandler('./routes/nytimes/index'));
 
 // 3dm

--- a/lib/routes/nytimes/author.js
+++ b/lib/routes/nytimes/author.js
@@ -1,0 +1,49 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const logger = require('../../utils/logger');
+const fs = require('fs');
+
+module.exports = async (ctx) => {
+    logger.info('author.js');
+    const byline = ctx.params.byline;
+
+    const authorUrl = `https://www.nytimes.com/by/${byline}`;
+
+    const response = await got({
+        method: 'get',
+        url: authorUrl,
+    });
+    const data = response.data;
+    const $ = cheerio.load(data);
+
+    const authorName = $('h1').text();
+    logger.info(authorName);
+
+    fs.writeFileSync('nyt.html', data);
+
+    const items = $('#stream-panel li')
+        .map((index, elem) => {
+            const $item = $(elem);
+            const $info = $item.find('div > div');
+            const title = $info.find('h2').text();
+            const href = $info.find('a').attr('href');
+            const link = new URL(href, authorUrl);
+            const description = $info.find('a > p').text();
+            const author = $info.find('a p > span').text();
+
+            return {
+                title,
+                author,
+                description,
+                link,
+            };
+        })
+        .get()
+        .filter((d) => d.title);
+
+    ctx.state.data = {
+        title: `${authorName} - The New York Times`,
+        link: authorUrl,
+        item: items,
+    };
+};


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Adds route for New York Times articles by specified author

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```
/nytimes/author/farhad-manjoo
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/nytimes/author/farhad-manjoo
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [x] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
